### PR TITLE
[permissions] robustness and QoL improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 .idea
 .vscode
+
+# generated policy.json file
+policy.json


### PR DESCRIPTION
- policies like `arn:aws:iam::aws:policy/AdministratorAccess` just return `*`
- policies like `arn:aws:iam::aws:policy/IAMFullAccess` return things like `iam:*`

when you see `*`, you should match to all the required policies
when you see things like `iam:*`, you should match to all iam policies 

this pr does that 