### PR TITLE
Uses external module for VPC

### DIFF
--- a/examples/aws/control-and-data-plane/main.tf
+++ b/examples/aws/control-and-data-plane/main.tf
@@ -237,7 +237,7 @@ module "efs" {
   aws_eks_cluster_auth_token = module.eks.aws_eks_cluster_auth_token
   provider_url               = module.eks.provider_url
 
-  security_group_ids = [module.vpc.private_security_group]
+  security_group_ids = [module.vpc.default_security_group_id]
   app_subnet_id_01   = module.vpc.private_subnets[0]
   app_subnet_id_02   = module.vpc.private_subnets[1]
 

--- a/examples/aws/control-and-data-plane/main.tf
+++ b/examples/aws/control-and-data-plane/main.tf
@@ -14,21 +14,26 @@ provider "aws" {
   region = var.region
 }
 
+data "aws_eks_cluster" "cluster-data" {
+  name = module.eks.name
+  depends_on = [module.eks]
+}
+
 data "aws_eks_cluster_auth" "cluster-auth" {
   name = module.eks.name
-  #depends_on = [module.eks]
+  depends_on = [module.eks]
 }
 
 provider "kubernetes" {
   host                   = module.eks.endpoint
-  cluster_ca_certificate = base64decode(module.eks.certificate-authority-data)
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster-data.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.cluster-auth.token
 }
 
 provider "helm" {
   kubernetes {
     host                   = module.eks.endpoint
-    cluster_ca_certificate = base64decode(module.eks.certificate-authority-data)
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster-data.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.cluster-auth.token
   }
 }

--- a/examples/aws/control-and-data-plane/terraform.tfvars
+++ b/examples/aws/control-and-data-plane/terraform.tfvars
@@ -1,4 +1,4 @@
-region = "us-west-2"
+region = "us-west-1"
 
 # EKS
 worker_instance_type = "m5.4xlarge"
@@ -7,7 +7,6 @@ max_node_size        = 4
 environment          = "devzero-final"
 
 # VPC
-availability_zones = ["us-west-2a", "us-west-2b"]
-cidr               = "10.0.0.0/16"
-private_subnets    = ["10.0.64.0/19", "10.0.96.0/19"]
-
+create_vpc = true
+availability_zones_count = 3
+cidr            = "10.0.0.0/16"

--- a/examples/aws/control-and-data-plane/variables.tf
+++ b/examples/aws/control-and-data-plane/variables.tf
@@ -37,19 +37,37 @@ variable "security_group_ids" {
 }
 
 # VPC
+variable "create_vpc" {
+  description = "Controls if VPC should be created (it affects almost all resources)"
+  type        = bool
+}
+
 variable "cidr" {
   type        = string
   description = "Cidr block"
 }
 
-variable "availability_zones" {
-  description = "Availability zones"
-  type        = list(string)
+variable "availability_zones_count" {
+  description = "The number of availability zones available for the VPC and EKS cluster"
+  type        = number
+  default     = 0
 }
 
+variable "availability_zones" {
+  description = "Availability zones. Required if availability_zones_count is not set"
+  type        = list(string)
+  default     = []
+}
+
+variable "public_subnets" {
+  description = "Public subnets. Optionally create public subnets"
+  type        = list(string)
+  default = []
+}
 
 variable "private_subnets" {
-  description = "Private subnets"
+  description = "Private subnets. Required if create_vpc is false"
   type        = list(string)
+  default = []
 }
 


### PR DESCRIPTION
By using an external, battle tested, module for the VPC we ansure that most good patterns and standards for both terraform and AWS are in place. This also helps people with previous experience with the module to contribute.
